### PR TITLE
Metadata schema bugs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "fairpm/did-manager-wordpress": "^0.0.3"
+        "fairpm/did-manager-wordpress": "^0.0.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efceb8f1f7189676b0cc31ac372018cd",
+    "content-hash": "4b548063c693a71020fdd661437c824f",
     "packages": [
         {
             "name": "afragen/wordpress-plugin-readme-parser",
@@ -54,16 +54,16 @@
         },
         {
             "name": "brick/math",
-            "version": "0.17.0",
+            "version": "0.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "a62af7ab2e3cee9f9bf4cf77a5d1e6ba408a44ee"
+                "reference": "6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/a62af7ab2e3cee9f9bf4cf77a5d1e6ba408a44ee",
-                "reference": "a62af7ab2e3cee9f9bf4cf77a5d1e6ba408a44ee",
+                "url": "https://api.github.com/repos/brick/math/zipball/6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b",
+                "reference": "6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b",
                 "shasum": ""
             },
             "require": {
@@ -101,7 +101,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.17.0"
+                "source": "https://github.com/brick/math/tree/0.17.1"
             },
             "funding": [
                 {
@@ -109,7 +109,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-17T12:54:54+00:00"
+            "time": "2026-04-19T20:55:20+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -169,30 +169,33 @@
         },
         {
             "name": "fairpm/did-manager",
-            "version": "0.0.3",
+            "version": "0.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fairpm/did-manager.git",
-                "reference": "68781633733c918d0d3a7deacfd3822ce1971134"
+                "reference": "28305a8d3b48b94b4f444268337129deb46154b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fairpm/did-manager/zipball/68781633733c918d0d3a7deacfd3822ce1971134",
-                "reference": "68781633733c918d0d3a7deacfd3822ce1971134",
+                "url": "https://api.github.com/repos/fairpm/did-manager/zipball/28305a8d3b48b94b4f444268337129deb46154b6",
+                "reference": "28305a8d3b48b94b4f444268337129deb46154b6",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
-                "php": ">=8.3",
+                "php": ">=8.0",
                 "simplito/elliptic-php": "^1.0",
                 "spomky-labs/cbor-php": "^3.1",
                 "yocto/yoclib-multibase": "^1.2"
             },
             "require-dev": {
-                "carthage-software/mago": "^1.0.0-rc.12",
-                "phpunit/phpunit": "^10.0",
-                "roave/security-advisories": "dev-latest"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^9.6",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -213,35 +216,38 @@
             "description": "Core PHP library for DID management, key handling, and PLC operations",
             "support": {
                 "issues": "https://github.com/fairpm/did-manager/issues",
-                "source": "https://github.com/fairpm/did-manager/tree/0.0.3"
+                "source": "https://github.com/fairpm/did-manager/tree/0.0.6"
             },
-            "time": "2026-03-13T18:34:47+00:00"
+            "time": "2026-05-19T17:15:37+00:00"
         },
         {
             "name": "fairpm/did-manager-wordpress",
-            "version": "0.0.3",
+            "version": "0.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fairpm/did-manager-wordpress.git",
-                "reference": "ea41d4945b4a2411e9a3b37c6e1c8264d7101592"
+                "reference": "b77c55e2dff005f77f9878939df52ef81a657317"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fairpm/did-manager-wordpress/zipball/ea41d4945b4a2411e9a3b37c6e1c8264d7101592",
-                "reference": "ea41d4945b4a2411e9a3b37c6e1c8264d7101592",
+                "url": "https://api.github.com/repos/fairpm/did-manager-wordpress/zipball/b77c55e2dff005f77f9878939df52ef81a657317",
+                "reference": "b77c55e2dff005f77f9878939df52ef81a657317",
                 "shasum": ""
             },
             "require": {
                 "afragen/wordpress-plugin-readme-parser": "^1.2025.12",
                 "erusev/parsedown": "^1.7",
                 "ext-json": "*",
-                "fairpm/did-manager": "^0.0.3",
-                "php": ">=8.3"
+                "fairpm/did-manager": "0.0.6",
+                "php": ">=8.0"
             },
             "require-dev": {
-                "carthage-software/mago": "^1.0.0-rc.12",
-                "phpunit/phpunit": "^10.0",
-                "roave/security-advisories": "dev-latest"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^9.0",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
             "autoload": {
@@ -262,9 +268,9 @@
             "description": "WordPress integration layer for FAIR DID management and metadata generation",
             "support": {
                 "issues": "https://github.com/fairpm/did-manager-wordpress/issues",
-                "source": "https://github.com/fairpm/did-manager-wordpress/tree/0.0.3"
+                "source": "https://github.com/fairpm/did-manager-wordpress/tree/0.0.6"
             },
-            "time": "2026-04-05T09:44:40+00:00"
+            "time": "2026-05-19T17:57:49+00:00"
         },
         {
             "name": "simplito/bigint-wrapper-php",
@@ -2204,10 +2210,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/schemas/fair-package-metadata.schema.json
+++ b/schemas/fair-package-metadata.schema.json
@@ -1,0 +1,248 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://fair.pm/schemas/fair-package-metadata.schema.json",
+    "title": "FAIR Package Metadata",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "@context",
+        "id",
+        "type",
+        "name",
+        "slug",
+        "filename",
+        "last_updated",
+        "releases"
+    ],
+    "properties": {
+        "@context": {
+            "type": "string",
+            "const": "https://fair.pm/ns/metadata/v1"
+        },
+        "id": {
+            "type": "string",
+            "pattern": "^did:"
+        },
+        "type": {
+            "type": "string",
+            "enum": ["wp-plugin", "wp-theme"]
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1
+        },
+        "slug": {
+            "type": "string",
+            "minLength": 1
+        },
+        "filename": {
+            "type": "string",
+            "minLength": 1
+        },
+        "description": {
+            "type": "string"
+        },
+        "authors": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                }
+            }
+        },
+        "license": {
+            "type": "string",
+            "minLength": 1
+        },
+        "security": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "anyOf": [
+                    {
+                        "required": ["email"]
+                    },
+                    {
+                        "required": ["url"]
+                    }
+                ]
+            }
+        },
+        "keywords": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "sections": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "last_updated": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "releases": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/$defs/release"
+            }
+        }
+    },
+    "$defs": {
+        "release": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "version",
+                "requires",
+                "suggests",
+                "provides",
+                "artifacts"
+            ],
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "requires": {
+                    "$ref": "#/$defs/constraintMap"
+                },
+                "suggests": {
+                    "$ref": "#/$defs/constraintMap"
+                },
+                "provides": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "artifacts": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["package"],
+                    "properties": {
+                        "package": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/$defs/packageArtifact"
+                            }
+                        },
+                        "icon": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/$defs/imageArtifact"
+                            }
+                        },
+                        "banner": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/$defs/imageArtifact"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "constraintMap": {
+            "type": "object",
+            "propertyNames": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9:_-]+$"
+            },
+            "additionalProperties": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "packageArtifact": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "url",
+                "content-type",
+                "signature",
+                "checksum"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "content-type": {
+                    "type": "string",
+                    "const": "application/zip"
+                },
+                "signature": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "checksum": {
+                    "type": "string",
+                    "pattern": "^sha256:[0-9a-f]{64}$"
+                }
+            }
+        },
+        "imageArtifact": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "url",
+                "content-type",
+                "height",
+                "width"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "content-type": {
+                    "type": "string",
+                    "pattern": "^image/"
+                },
+                "height": {
+                    "type": ["integer", "null"],
+                    "minimum": 1
+                },
+                "width": {
+                    "type": ["integer", "null"],
+                    "minimum": 1
+                }
+            }
+        }
+    }
+}

--- a/src/actions/PublishFairAction.php
+++ b/src/actions/PublishFairAction.php
@@ -343,10 +343,7 @@ final class PublishFairAction
     {
         $this->runtime->logger()->group($label);
 
-        $outputFile = tempnam(sys_get_temp_dir(), 'fair-output-');
-        if ($outputFile === false) {
-            throw new \RuntimeException('Could not create temporary output file for action step.');
-        }
+        $outputFile = $this->createStepOutputFile();
 
         $mergedEnv = $this->buildProcessEnv(array_merge($env, ['GITHUB_OUTPUT' => $outputFile]));
 
@@ -387,6 +384,55 @@ final class PublishFairAction
         $this->runtime->logger()->endGroup();
 
         return $parsed;
+    }
+
+    private function createStepOutputFile(): string
+    {
+        foreach ($this->stepOutputDirectories() as $directory) {
+            for ($attempt = 0; $attempt < 5; $attempt++) {
+                $path = rtrim($directory, '/\\') . DIRECTORY_SEPARATOR . 'fair-output-' . bin2hex(random_bytes(8));
+                $created = @file_put_contents($path, '');
+                if ($created !== false) {
+                    return $path;
+                }
+            }
+        }
+
+        throw new \RuntimeException('Could not create temporary output file for action step.');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stepOutputDirectories(): array
+    {
+        $candidates = [];
+
+        $githubOutput = $this->runtime->env()->get('GITHUB_OUTPUT') ?? '';
+        if ($githubOutput !== '') {
+            $candidates[] = dirname($githubOutput);
+        }
+
+        $workspace = $this->runtime->env()->get('GITHUB_WORKSPACE') ?? '';
+        if ($workspace !== '') {
+            $candidates[] = $workspace;
+        }
+
+        $tempDir = sys_get_temp_dir();
+        if ($tempDir !== '') {
+            $candidates[] = $tempDir;
+        }
+
+        $directories = [];
+        foreach (array_unique($candidates) as $candidate) {
+            if (!is_string($candidate) || $candidate === '' || !is_dir($candidate) || !is_writable($candidate)) {
+                continue;
+            }
+
+            $directories[] = $candidate;
+        }
+
+        return $directories;
     }
 
     /**

--- a/src/services/FairMetadataSchemaValidator.php
+++ b/src/services/FairMetadataSchemaValidator.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FairPulse\Services;
+
+final class FairMetadataSchemaValidator
+{
+    private ?array $schema = null;
+
+    public function __construct(private readonly string $schemaPath = __DIR__ . '/../../schemas/fair-package-metadata.schema.json')
+    {
+    }
+
+    public function validate(array $metadata): void
+    {
+        $schema = $this->loadSchema();
+        $errors = $this->validateValue($metadata, $schema, '$', $schema);
+
+        if ($errors !== []) {
+            throw new \RuntimeException(
+                'Generated metadata does not conform to FAIR schema: ' . implode('; ', $errors)
+            );
+        }
+    }
+
+    private function loadSchema(): array
+    {
+        if ($this->schema !== null) {
+            return $this->schema;
+        }
+
+        $contents = file_get_contents($this->schemaPath);
+        if ($contents === false) {
+            throw new \RuntimeException('Could not read FAIR metadata schema at ' . $this->schemaPath);
+        }
+
+        $decoded = json_decode($contents, true);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException('Could not decode FAIR metadata schema at ' . $this->schemaPath);
+        }
+
+        $this->schema = $decoded;
+
+        return $this->schema;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validateValue(mixed $value, array $schema, string $path, array $rootSchema): array
+    {
+        if (isset($schema['$ref']) && is_string($schema['$ref'])) {
+            return $this->validateValue($value, $this->resolveRef($schema['$ref'], $rootSchema), $path, $rootSchema);
+        }
+
+        if (isset($schema['anyOf']) && is_array($schema['anyOf'])) {
+            foreach ($schema['anyOf'] as $option) {
+                if (!is_array($option)) {
+                    continue;
+                }
+
+                if ($this->validateValue($value, $option, $path, $rootSchema) === []) {
+                    return [];
+                }
+            }
+
+            return [$path . ' does not satisfy any allowed schema option'];
+        }
+
+        $errors = [];
+        $expectedTypes = $this->normalizeTypes($schema['type'] ?? null);
+
+        if ($expectedTypes !== [] && !$this->matchesAnyType($value, $expectedTypes)) {
+            return [$path . ' must be of type ' . implode('|', $expectedTypes)];
+        }
+
+        if (array_key_exists('const', $schema) && $value !== $schema['const']) {
+            $errors[] = $path . ' must equal ' . var_export($schema['const'], true);
+        }
+
+        if (isset($schema['enum']) && is_array($schema['enum']) && !in_array($value, $schema['enum'], true)) {
+            $errors[] = $path . ' must be one of the allowed values';
+        }
+
+        if (is_string($value)) {
+            if (isset($schema['minLength']) && mb_strlen($value) < (int) $schema['minLength']) {
+                $errors[] = $path . ' must be at least ' . (int) $schema['minLength'] . ' characters';
+            }
+
+            if (isset($schema['pattern']) && is_string($schema['pattern'])) {
+                $pattern = '/' . str_replace('/', '\\/', $schema['pattern']) . '/';
+                if (@preg_match($pattern, $value) !== 1) {
+                    $errors[] = $path . ' does not match the required pattern';
+                }
+            }
+
+            if (isset($schema['format']) && is_string($schema['format'])) {
+                $formatError = $this->validateFormat($value, $schema['format'], $path);
+                if ($formatError !== null) {
+                    $errors[] = $formatError;
+                }
+            }
+        }
+
+        if (is_array($value) && array_is_list($value)) {
+            if (isset($schema['minItems']) && count($value) < (int) $schema['minItems']) {
+                $errors[] = $path . ' must contain at least ' . (int) $schema['minItems'] . ' item(s)';
+            }
+
+            if (isset($schema['items']) && is_array($schema['items'])) {
+                foreach ($value as $index => $item) {
+                    $errors = array_merge(
+                        $errors,
+                        $this->validateValue($item, $schema['items'], $path . '[' . $index . ']', $rootSchema)
+                    );
+                }
+            }
+        }
+
+        $isObjectLike = is_object($value) || (is_array($value) && !array_is_list($value));
+        if ($isObjectLike) {
+            $objectValue = is_object($value) ? get_object_vars($value) : $value;
+
+            if (isset($schema['minProperties']) && count($value) < (int) $schema['minProperties']) {
+                $errors[] = $path . ' must contain at least ' . (int) $schema['minProperties'] . ' propert(ies)';
+            }
+
+            $properties = isset($schema['properties']) && is_array($schema['properties']) ? $schema['properties'] : [];
+            $required = isset($schema['required']) && is_array($schema['required']) ? $schema['required'] : [];
+
+            foreach ($required as $requiredKey) {
+                if (is_string($requiredKey) && !array_key_exists($requiredKey, $objectValue)) {
+                    $errors[] = $path . '.' . $requiredKey . ' is required';
+                }
+            }
+
+            if (isset($schema['propertyNames']) && is_array($schema['propertyNames'])) {
+                foreach (array_keys($objectValue) as $key) {
+                    $errors = array_merge(
+                        $errors,
+                        $this->validateValue((string) $key, $schema['propertyNames'], $path . ' property name', $rootSchema)
+                    );
+                }
+            }
+
+            foreach ($objectValue as $key => $item) {
+                if (isset($properties[$key]) && is_array($properties[$key])) {
+                    $errors = array_merge(
+                        $errors,
+                        $this->validateValue($item, $properties[$key], $path . '.' . $key, $rootSchema)
+                    );
+                    continue;
+                }
+
+                if (($schema['additionalProperties'] ?? true) === false) {
+                    $errors[] = $path . '.' . $key . ' is not allowed';
+                    continue;
+                }
+
+                if (isset($schema['additionalProperties']) && is_array($schema['additionalProperties'])) {
+                    $errors = array_merge(
+                        $errors,
+                        $this->validateValue($item, $schema['additionalProperties'], $path . '.' . $key, $rootSchema)
+                    );
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeTypes(mixed $types): array
+    {
+        if (is_string($types)) {
+            return [$types];
+        }
+
+        if (!is_array($types)) {
+            return [];
+        }
+
+        return array_values(array_filter($types, 'is_string'));
+    }
+
+    /**
+     * @param list<string> $types
+     */
+    private function matchesAnyType(mixed $value, array $types): bool
+    {
+        foreach ($types as $type) {
+            if ($this->matchesType($value, $type)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function matchesType(mixed $value, string $type): bool
+    {
+        return match ($type) {
+            'object' => is_object($value) || (is_array($value) && !array_is_list($value)),
+            'array' => is_array($value) && array_is_list($value),
+            'string' => is_string($value),
+            'integer' => is_int($value),
+            'null' => $value === null,
+            'boolean' => is_bool($value),
+            default => true,
+        };
+    }
+
+    private function validateFormat(string $value, string $format, string $path): ?string
+    {
+        return match ($format) {
+            'uri' => filter_var($value, FILTER_VALIDATE_URL) === false ? $path . ' must be a valid URI' : null,
+            'email' => filter_var($value, FILTER_VALIDATE_EMAIL) === false ? $path . ' must be a valid email address' : null,
+            'date-time' => $this->isValidDateTime($value) ? null : $path . ' must be a valid date-time',
+            default => null,
+        };
+    }
+
+    private function isValidDateTime(string $value): bool
+    {
+        try {
+            new \DateTimeImmutable($value);
+            return true;
+        } catch (\Exception) {
+            return false;
+        }
+    }
+
+    private function resolveRef(string $ref, array $rootSchema): array
+    {
+        if (!str_starts_with($ref, '#/')) {
+            throw new \RuntimeException('Unsupported schema reference: ' . $ref);
+        }
+
+        $node = $rootSchema;
+        foreach (explode('/', substr($ref, 2)) as $segment) {
+            if (!is_array($node) || !array_key_exists($segment, $node)) {
+                throw new \RuntimeException('Could not resolve schema reference: ' . $ref);
+            }
+
+            $node = $node[$segment];
+        }
+
+        if (!is_array($node)) {
+            throw new \RuntimeException('Resolved schema reference is not an object: ' . $ref);
+        }
+
+        return $node;
+    }
+}

--- a/src/services/MetadataGenerationService.php
+++ b/src/services/MetadataGenerationService.php
@@ -37,35 +37,99 @@ final class MetadataGenerationService
         $artifactFilename = basename($artifactPath);
         $releaseUrl = $repoUrl . "/releases/download/{$version}/{$artifactFilename}";
 
-        $metadata = $generator->generate();
-        $metadata['releases'] = [
-            [
-                'version' => ltrim($version, 'v'),
-                'requires' => [
-                    'env:php' => '>=' . ($headerData['RequiresPHP'] ?? '7.4'),
-                    'env:wp' => '>=' . ($headerData['RequiresAtLeast'] ?? '6.0'),
-                ],
-                'artifacts' => [
-                    'package' => [
-                        [
-                            'id' => 'main',
-                            'url' => $releaseUrl,
-                            'content-type' => 'application/zip',
-                            'signature' => $signature,
-                            'checksum' => $checksum,
-                        ],
-                    ],
-                ],
+        $metadata = $this->normalizeMetadata(
+            $generator->generate(),
+            $did,
+            $version,
+            $checksum,
+            $signature,
+            $mainPluginFile,
+            $releaseUrl,
+            $headerData,
+            $readmeData,
+        );
+
+        (new FairMetadataSchemaValidator())->validate($metadata);
+
+        return $metadata;
+    }
+
+    private function normalizeMetadata(
+        array $rawMetadata,
+        string $did,
+        string $version,
+        string $checksum,
+        string $signature,
+        string $mainPluginFile,
+        string $releaseUrl,
+        array $headerData,
+        array $readmeData,
+    ): array {
+        $slug = $this->firstString(
+            $rawMetadata,
+            ['slug']
+        );
+        if ($slug === '') {
+            $slug = $this->firstString($headerData, ['text_domain', 'TextDomain']);
+        }
+        if ($slug === '') {
+            $slug = pathinfo($mainPluginFile, PATHINFO_FILENAME);
+        }
+
+        $name = $this->firstString($rawMetadata, ['name']);
+        if ($name === '') {
+            $name = $this->firstString($headerData, ['plugin_name', 'PluginName', 'theme_name', 'ThemeName']);
+        }
+        if ($name === '') {
+            $name = $slug;
+        }
+
+        $description = $this->firstString($rawMetadata, ['description']);
+        if ($description === '') {
+            $description = $this->firstString($readmeData, ['description', 'short_description']);
+        }
+
+        $metadata = [
+            '@context' => 'https://fair.pm/ns/metadata/v1',
+            'id' => $did,
+            'type' => $this->normalizeMetadataType($rawMetadata['type'] ?? null),
+            'name' => $name,
+            'slug' => $slug,
+            'filename' => $slug . '/' . basename($mainPluginFile),
+            'last_updated' => gmdate('Y-m-d\\TH:i:s\\Z'),
+            'releases' => [
+                $this->buildRelease($version, $checksum, $signature, $releaseUrl, $headerData, $readmeData),
             ],
         ];
 
-        if (!isset($metadata['@context'])) {
-            $metadata['@context'] = 'https://fair.pm/ns/metadata/v1';
+        if ($description !== '') {
+            $metadata['description'] = $description;
         }
-        if (!isset($metadata['id'])) {
-            $metadata['id'] = $did;
+
+        $authors = $this->normalizeAuthors($rawMetadata['authors'] ?? null, $headerData);
+        if ($authors !== []) {
+            $metadata['authors'] = $authors;
         }
-        $metadata['type'] = $this->normalizeMetadataType($metadata['type'] ?? null);
+
+        $license = $this->normalizeLicense($rawMetadata['license'] ?? null, $headerData, $readmeData);
+        if ($license !== null) {
+            $metadata['license'] = $license;
+        }
+
+        $security = $this->normalizeSecurity($rawMetadata['security'] ?? null, $headerData);
+        if ($security !== []) {
+            $metadata['security'] = $security;
+        }
+
+        $keywords = $this->normalizeKeywords($rawMetadata['keywords'] ?? ($rawMetadata['tags'] ?? null));
+        if ($keywords !== []) {
+            $metadata['keywords'] = $keywords;
+        }
+
+        $sections = $this->normalizeSections($rawMetadata['sections'] ?? null, $description);
+        if ($sections !== []) {
+            $metadata['sections'] = $sections;
+        }
 
         return $metadata;
     }
@@ -99,5 +163,222 @@ final class MetadataGenerationService
         }
 
         return $value;
+    }
+
+    private function buildRelease(
+        string $version,
+        string $checksum,
+        string $signature,
+        string $releaseUrl,
+        array $headerData,
+        array $readmeData,
+    ): array {
+        $requiresPhp = $this->findRequirement($headerData, $readmeData, ['requires_php', 'RequiresPHP'], '7.4');
+        $requiresWp = $this->findRequirement($headerData, $readmeData, ['requires_at_least', 'RequiresAtLeast'], '6.0');
+
+        return [
+            'version' => ltrim($version, 'v'),
+            'requires' => [
+                'env:php' => '>=' . $requiresPhp,
+                'env:wp' => '>=' . $requiresWp,
+            ],
+            'suggests' => new \stdClass(),
+            'provides' => [],
+            'artifacts' => [
+                'package' => [
+                    [
+                        'url' => $releaseUrl,
+                        'content-type' => 'application/zip',
+                        'signature' => $signature,
+                        'checksum' => $checksum,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function findRequirement(array $headerData, array $readmeData, array $headerKeys, string $default): string
+    {
+        $headerValue = $this->firstString($headerData, $headerKeys);
+        if ($headerValue !== '') {
+            return $headerValue;
+        }
+
+        if (isset($readmeData['header']) && is_array($readmeData['header'])) {
+            $readmeValue = $this->firstString($readmeData['header'], $headerKeys);
+            if ($readmeValue !== '') {
+                return $readmeValue;
+            }
+        }
+
+        return $default;
+    }
+
+    private function normalizeAuthors(mixed $authors, array $headerData): array
+    {
+        if (is_array($authors)) {
+            $normalized = [];
+            foreach ($authors as $author) {
+                if (!is_array($author)) {
+                    continue;
+                }
+
+                $name = isset($author['name']) && is_string($author['name']) ? trim($author['name']) : '';
+                if ($name === '') {
+                    continue;
+                }
+
+                $entry = ['name' => $name];
+                if (isset($author['url']) && is_string($author['url']) && trim($author['url']) !== '') {
+                    $entry['url'] = trim($author['url']);
+                }
+                $normalized[] = $entry;
+            }
+
+            if ($normalized !== []) {
+                return $normalized;
+            }
+        }
+
+        $author = $this->firstString($headerData, ['author', 'Author']);
+        if ($author === '') {
+            return [];
+        }
+
+        $normalized = [['name' => $author]];
+        $authorUrl = $this->firstString($headerData, ['author_uri', 'AuthorURI']);
+        if ($authorUrl !== '') {
+            $normalized[0]['url'] = $authorUrl;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeLicense(mixed $license, array $headerData, array $readmeData): ?string
+    {
+        if (is_string($license) && trim($license) !== '') {
+            return trim($license);
+        }
+
+        if (is_array($license) && isset($license['name']) && is_string($license['name']) && trim($license['name']) !== '') {
+            return trim($license['name']);
+        }
+
+        $headerLicense = $this->firstString($headerData, ['license', 'License']);
+        if ($headerLicense !== '') {
+            return $headerLicense;
+        }
+
+        if (isset($readmeData['header']) && is_array($readmeData['header'])) {
+            $readmeLicense = $this->firstString($readmeData['header'], ['license', 'License']);
+            if ($readmeLicense !== '') {
+                return $readmeLicense;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeSecurity(mixed $security, array $headerData): array
+    {
+        if (is_array($security)) {
+            $normalized = [];
+            foreach ($security as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+
+                if (isset($entry['email']) && is_string($entry['email']) && trim($entry['email']) !== '') {
+                    $normalized[] = ['email' => trim($entry['email'])];
+                    continue;
+                }
+
+                if (isset($entry['url']) && is_string($entry['url']) && trim($entry['url']) !== '') {
+                    $normalized[] = ['url' => trim($entry['url'])];
+                }
+            }
+
+            if ($normalized !== []) {
+                return $normalized;
+            }
+        }
+
+        $securityValue = $this->firstString($headerData, ['security', 'Security']);
+        if ($securityValue === '') {
+            return [];
+        }
+
+        if (filter_var($securityValue, FILTER_VALIDATE_EMAIL) !== false) {
+            return [['email' => $securityValue]];
+        }
+
+        if (filter_var($securityValue, FILTER_VALIDATE_URL) !== false) {
+            return [['url' => $securityValue]];
+        }
+
+        return [];
+    }
+
+    private function normalizeKeywords(mixed $keywords): array
+    {
+        if (!is_array($keywords)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($keywords as $keyword) {
+            if (!is_string($keyword)) {
+                continue;
+            }
+
+            $keyword = trim($keyword);
+            if ($keyword === '') {
+                continue;
+            }
+
+            $normalized[] = $keyword;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function normalizeSections(mixed $sections, string $description): array
+    {
+        if (is_array($sections)) {
+            $normalized = [];
+            foreach ($sections as $key => $value) {
+                if (!is_string($key) || !is_string($value) || trim($value) === '') {
+                    continue;
+                }
+
+                $normalized[$key] = $value;
+            }
+
+            if ($normalized !== []) {
+                return $normalized;
+            }
+        }
+
+        if ($description !== '') {
+            return ['description' => $description];
+        }
+
+        return [];
+    }
+
+    private function firstString(array $source, array $keys): string
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $source) || !is_string($source[$key])) {
+                continue;
+            }
+
+            $value = trim($source[$key]);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
     }
 }

--- a/tests/E2E/PublishFairActionE2ETest.php
+++ b/tests/E2E/PublishFairActionE2ETest.php
@@ -56,7 +56,7 @@ echo "unsupported gh command: $*" >&2
 exit 1
 BASH;
 
-        file_put_contents($ghPath, $ghScript);
+        $this->writeExecutableScript($ghPath, $ghScript);
         chmod($ghPath, 0755);
 
         $outputFile = tempnam(sys_get_temp_dir(), 'fair-e2e-output-');
@@ -152,7 +152,7 @@ echo "unsupported gh command: $*" >&2
 exit 1
 BASH;
 
-        file_put_contents($ghPath, $ghScript);
+        $this->writeExecutableScript($ghPath, $ghScript);
         chmod($ghPath, 0755);
 
         $outputFile = tempnam(sys_get_temp_dir(), 'fair-e2e-output-');
@@ -311,7 +311,7 @@ BASH;
     exit 1
     BASH;
 
-        file_put_contents($ghPath, $ghScript);
+        $this->writeExecutableScript($ghPath, $ghScript);
         chmod($ghPath, 0755);
 
         $outputFile = tempnam(sys_get_temp_dir(), 'fair-e2e-output-');
@@ -391,7 +391,7 @@ echo "unsupported gh command: $*" >&2
 exit 1
 BASH;
 
-        file_put_contents($ghPath, $ghScript);
+        $this->writeExecutableScript($ghPath, $ghScript);
         chmod($ghPath, 0755);
 
         $outputFile = tempnam(sys_get_temp_dir(), 'fair-e2e-output-');
@@ -465,4 +465,9 @@ BASH;
         self::assertSame(1, $result->exitCode);
         self::assertStringContainsString('FAIR_DID is required', $result->stdout);
     }
+
+      private function writeExecutableScript(string $path, string $contents): void
+      {
+        file_put_contents($path, str_replace("\r\n", "\n", $contents));
+      }
 }

--- a/tests/GenerateMetadataScriptTest.php
+++ b/tests/GenerateMetadataScriptTest.php
@@ -50,8 +50,51 @@ final class GenerateMetadataScriptTest extends TestCase
 
         $metadata = json_decode((string) file_get_contents('/tmp/fair-metadata.json'), true, 512, JSON_THROW_ON_ERROR);
         self::assertSame('did:plc:metadata123', $metadata['id']);
+        self::assertSame('https://fair.pm/ns/metadata/v1', $metadata['@context']);
         self::assertSame('wp-plugin', $metadata['type']);
+        self::assertSame('example-plugin/example-plugin.php', $metadata['filename']);
         self::assertSame('1.2.3', $metadata['releases'][0]['version']);
         self::assertSame('signature123', $metadata['releases'][0]['artifacts']['package'][0]['signature']);
+        self::assertSame('sha256:' . str_repeat('a', 64), $metadata['releases'][0]['artifacts']['package'][0]['checksum']);
+        self::assertSame([], $metadata['releases'][0]['suggests']);
+        self::assertSame([], $metadata['releases'][0]['provides']);
+        self::assertArrayNotHasKey('generatedAt', $metadata);
+        self::assertArrayNotHasKey('tags', $metadata);
+    }
+
+    public function testGenerationFailsWhenSchemaRequirementsAreMissing(): void
+    {
+        $workspaceDir = sys_get_temp_dir() . '/fair-workspace-' . bin2hex(random_bytes(5));
+        mkdir($workspaceDir, 0777, true);
+
+        file_put_contents(
+            $workspaceDir . '/example-plugin.php',
+            "<?php\n/*\nPlugin Name: Example Plugin\nRequires PHP: 8.1\nRequires at least: 6.5\n*/\n"
+        );
+
+        file_put_contents($workspaceDir . '/readme.txt', "Example plugin readme.\n");
+
+        $artifactPath = tempnam(sys_get_temp_dir(), 'fair-artifact-');
+        file_put_contents($artifactPath, 'artifact-content');
+
+        $outputFile = tempnam(sys_get_temp_dir(), 'fair-output-');
+
+        $result = ScriptRunner::run(
+            __DIR__ . '/../src/actions/GenerateMetadataAction.php',
+            [
+                'GITHUB_OUTPUT' => $outputFile,
+                'GITHUB_WORKSPACE' => $workspaceDir,
+                'DID' => 'did:plc:metadata123',
+                'VERSION' => 'v1.2.3',
+                'CHECKSUM' => '',
+                'SIGNATURE' => '',
+                'ARTIFACT_PATH' => $artifactPath,
+                'VERIFICATION_PUBLIC' => 'verification-public',
+                'REPO_URL' => 'https://github.com/fairpm/fair-pulse',
+            ]
+        );
+
+        self::assertSame(1, $result->exitCode);
+        self::assertStringContainsString('Generated metadata does not conform to FAIR schema', $result->stdout);
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to FAIR package metadata handling, including the addition of a formal JSON schema for metadata validation, the implementation of a schema validator service, and enhancements to metadata normalization and validation during generation. It also updates a dependency and improves the reliability of temporary output file creation for publishing actions.

**FAIR Metadata Schema and Validation:**

* Added a comprehensive JSON schema (`fair-package-metadata.schema.json`) to formally define the structure and constraints of FAIR package metadata.
* Introduced the `FairMetadataSchemaValidator` service, which loads the schema and validates metadata arrays against it, throwing detailed errors on validation failure.
* Updated the metadata generation process in `MetadataGenerationService` to normalize metadata fields and validate the final result against the schema before returning.

**Dependency Update:**

* Updated the required version of `fairpm/did-manager-wordpress` in `composer.json` from `^0.0.3` to `^0.0.6` to ensure compatibility with recent changes.

**Action Output File Handling:**

* Improved temporary output file creation in `PublishFairAction` by adding a robust method that tries multiple directories and attempts, increasing reliability in CI and diverse environments. [[1]](diffhunk://#diff-5b65330e35203518a59e38e8d72bfe9338e930fee14b45d002dc2b09a0965d2cL346-R346) [[2]](diffhunk://#diff-5b65330e35203518a59e38e8d72bfe9338e930fee14b45d002dc2b09a0965d2cR389-R437)