### PR TITLE
Deduplicate entries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "fairpm/did-manager-wordpress": "^0.0.6"
+        "fairpm/did-manager-wordpress": "0.0.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b548063c693a71020fdd661437c824f",
+    "content-hash": "1f0647d6e781b4a0debc163c9c00d450",
     "packages": [
         {
             "name": "afragen/wordpress-plugin-readme-parser",
@@ -222,16 +222,16 @@
         },
         {
             "name": "fairpm/did-manager-wordpress",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fairpm/did-manager-wordpress.git",
-                "reference": "b77c55e2dff005f77f9878939df52ef81a657317"
+                "reference": "376b42c430dc84f15cc2d6e40122df8b6da6613a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fairpm/did-manager-wordpress/zipball/b77c55e2dff005f77f9878939df52ef81a657317",
-                "reference": "b77c55e2dff005f77f9878939df52ef81a657317",
+                "url": "https://api.github.com/repos/fairpm/did-manager-wordpress/zipball/376b42c430dc84f15cc2d6e40122df8b6da6613a",
+                "reference": "376b42c430dc84f15cc2d6e40122df8b6da6613a",
                 "shasum": ""
             },
             "require": {
@@ -268,9 +268,9 @@
             "description": "WordPress integration layer for FAIR DID management and metadata generation",
             "support": {
                 "issues": "https://github.com/fairpm/did-manager-wordpress/issues",
-                "source": "https://github.com/fairpm/did-manager-wordpress/tree/0.0.6"
+                "source": "https://github.com/fairpm/did-manager-wordpress/tree/0.0.7"
             },
-            "time": "2026-05-19T17:57:49+00:00"
+            "time": "2026-05-20T08:07:43+00:00"
         },
         {
             "name": "simplito/bigint-wrapper-php",
@@ -2210,10 +2210,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/src/services/MetadataGenerationService.php
+++ b/src/services/MetadataGenerationService.php
@@ -236,7 +236,22 @@ final class MetadataGenerationService
             }
 
             if ($normalized !== []) {
-                return $normalized;
+                return $this->deduplicateEntries(
+                    $normalized,
+                    static fn (array $author): string => strtolower($author['name']),
+                    static function (array $existing, array $candidate): array {
+                        if (
+                            !isset($existing['url'])
+                            && isset($candidate['url'])
+                            && is_string($candidate['url'])
+                            && trim($candidate['url']) !== ''
+                        ) {
+                            $existing['url'] = trim($candidate['url']);
+                        }
+
+                        return $existing;
+                    }
+                );
             }
         }
 
@@ -251,7 +266,49 @@ final class MetadataGenerationService
             $normalized[0]['url'] = $authorUrl;
         }
 
-        return $normalized;
+        return $this->deduplicateEntries(
+            $normalized,
+            static fn (array $author): string => strtolower($author['name']),
+            static function (array $existing, array $candidate): array {
+                if (
+                    !isset($existing['url'])
+                    && isset($candidate['url'])
+                    && is_string($candidate['url'])
+                    && trim($candidate['url']) !== ''
+                ) {
+                    $existing['url'] = trim($candidate['url']);
+                }
+
+                return $existing;
+            }
+        );
+    }
+
+    private function deduplicateEntries(array $entries, callable $keyResolver, ?callable $mergeEntry = null): array
+    {
+        $deduplicated = [];
+        $entryIndexes = [];
+
+        foreach ($entries as $entry) {
+            $key = $keyResolver($entry);
+            if (!is_string($key) || $key === '') {
+                continue;
+            }
+
+            if (isset($entryIndexes[$key])) {
+                if ($mergeEntry !== null) {
+                    $index = $entryIndexes[$key];
+                    $deduplicated[$index] = $mergeEntry($deduplicated[$index], $entry);
+                }
+
+                continue;
+            }
+
+            $entryIndexes[$key] = count($deduplicated);
+            $deduplicated[] = $entry;
+        }
+
+        return $deduplicated;
     }
 
     private function normalizeLicense(mixed $license, array $headerData, array $readmeData): ?string
@@ -299,7 +356,17 @@ final class MetadataGenerationService
             }
 
             if ($normalized !== []) {
-                return $normalized;
+                return $this->deduplicateEntries(
+                    $normalized,
+                    static function (array $entry): string {
+                        $type = array_key_first($entry);
+                        if (!is_string($type) || !isset($entry[$type]) || !is_string($entry[$type])) {
+                            return '';
+                        }
+
+                        return $type . ':' . $entry[$type];
+                    }
+                );
             }
         }
 
@@ -339,7 +406,10 @@ final class MetadataGenerationService
             $normalized[] = $keyword;
         }
 
-        return array_values(array_unique($normalized));
+        return $this->deduplicateEntries(
+            $normalized,
+            static fn (string $keyword): string => $keyword,
+        );
     }
 
     private function normalizeSections(mixed $sections, string $description): array

--- a/tests/Unit/MetadataGenerationServiceTest.php
+++ b/tests/Unit/MetadataGenerationServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FairPulse\Tests\Unit;
+
+use FairPulse\Services\MetadataGenerationService;
+use PHPUnit\Framework\TestCase;
+
+final class MetadataGenerationServiceTest extends TestCase
+{
+    public function testGenerateDeduplicatesContributorThatMatchesPrimaryAuthor(): void
+    {
+        $workspaceDir = sys_get_temp_dir() . '/fair-workspace-' . bin2hex(random_bytes(5));
+        mkdir($workspaceDir, 0777, true);
+
+        file_put_contents(
+            $workspaceDir . '/example-plugin.php',
+            "<?php\n/*\nPlugin Name: Example Plugin\nAuthor: johndoe\nAuthor URI: https://example.com\nRequires PHP: 8.1\nRequires at least: 6.5\n*/\n"
+        );
+
+        file_put_contents(
+            $workspaceDir . '/readme.txt',
+            "=== Example Plugin ===\n"
+            . "Contributors: johndoe\n"
+            . "Requires at least: 6.5\n"
+            . "Requires PHP: 8.1\n"
+            . "Stable tag: 1.2.3\n"
+            . "License: GPL-2.0-or-later\n\n"
+            . "Example plugin short description.\n"
+        );
+
+        $artifactPath = tempnam(sys_get_temp_dir(), 'fair-artifact-');
+        file_put_contents($artifactPath, 'artifact-content');
+
+        $service = new MetadataGenerationService();
+        $metadata = $service->generate(
+            'did:plc:metadata123',
+            'v1.2.3',
+            'sha256:' . str_repeat('a', 64),
+            'signature123',
+            $artifactPath,
+            'https://github.com/fairpm/fair-pulse',
+            $workspaceDir,
+        );
+
+        self::assertSame(
+            [['name' => 'johndoe', 'url' => 'https://example.com']],
+            $metadata['authors'] ?? null,
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces improvements to how metadata entries such as authors, keywords, and security entries are deduplicated in the `MetadataGenerationService`, and adds a new unit test to verify correct deduplication of contributors. The changes centralize deduplication logic, making the codebase more maintainable and consistent, and ensure that duplicate metadata entries are merged appropriately.

**Metadata deduplication improvements:**

* Introduced a new private method `deduplicateEntries` in `MetadataGenerationService.php` to handle deduplication for various metadata arrays, allowing for custom key resolution and entry merging logic. This method is now used in the normalization of authors, keywords, and security entries.
* Updated `normalizeAuthors`, `normalizeKeywords`, and `normalizeSecurity` to use the new `deduplicateEntries` method, ensuring consistent and more robust deduplication across different metadata fields. For authors, the logic merges URLs when duplicates are found. [[1]](diffhunk://#diff-ef865240431524810ba41db723b7247d848f003ddc4abd741697523ac04e1721L239-R254) [[2]](diffhunk://#diff-ef865240431524810ba41db723b7247d848f003ddc4abd741697523ac04e1721L254-R311) [[3]](diffhunk://#diff-ef865240431524810ba41db723b7247d848f003ddc4abd741697523ac04e1721L302-R369) [[4]](diffhunk://#diff-ef865240431524810ba41db723b7247d848f003ddc4abd741697523ac04e1721L342-R412)

**Testing and dependency updates:**

* Added a new unit test `MetadataGenerationServiceTest` to verify that a contributor matching the primary author is properly deduplicated, ensuring correct behavior of the deduplication logic.
* Updated the `composer.json` dependency for `fairpm/did-manager-wordpress` from version `^0.0.6` to `0.0.7`.