### PR TITLE
Use workspace directory name as slug

### DIFF
--- a/src/services/MetadataGenerationService.php
+++ b/src/services/MetadataGenerationService.php
@@ -70,16 +70,10 @@ final class MetadataGenerationService
     ): array {
         $slug = trim($packageSlug);
         if ($slug === '') {
-            $slug = $this->firstString(
-                $rawMetadata,
-                ['slug']
-            );
-        }
-        if ($slug === '') {
-            $slug = $this->firstString($headerData, ['text_domain', 'TextDomain']);
-        }
-        if ($slug === '') {
             $slug = pathinfo($mainPluginFile, PATHINFO_FILENAME);
+        }
+        if ($slug === '') {
+            throw new \RuntimeException('Could not determine package slug from workspace or plugin file.');
         }
 
         $name = $this->firstString($rawMetadata, ['name']);

--- a/src/services/MetadataGenerationService.php
+++ b/src/services/MetadataGenerationService.php
@@ -36,6 +36,7 @@ final class MetadataGenerationService
 
         $artifactFilename = basename($artifactPath);
         $releaseUrl = $repoUrl . "/releases/download/{$version}/{$artifactFilename}";
+        $packageSlug = basename(rtrim($workDir, '/\\'));
 
         $metadata = $this->normalizeMetadata(
             $generator->generate(),
@@ -43,6 +44,7 @@ final class MetadataGenerationService
             $version,
             $checksum,
             $signature,
+            $packageSlug,
             $mainPluginFile,
             $releaseUrl,
             $headerData,
@@ -60,15 +62,19 @@ final class MetadataGenerationService
         string $version,
         string $checksum,
         string $signature,
+        string $packageSlug,
         string $mainPluginFile,
         string $releaseUrl,
         array $headerData,
         array $readmeData,
     ): array {
-        $slug = $this->firstString(
-            $rawMetadata,
-            ['slug']
-        );
+        $slug = trim($packageSlug);
+        if ($slug === '') {
+            $slug = $this->firstString(
+                $rawMetadata,
+                ['slug']
+            );
+        }
         if ($slug === '') {
             $slug = $this->firstString($headerData, ['text_domain', 'TextDomain']);
         }

--- a/tests/GenerateMetadataScriptTest.php
+++ b/tests/GenerateMetadataScriptTest.php
@@ -49,10 +49,12 @@ final class GenerateMetadataScriptTest extends TestCase
         self::assertStringContainsString('metadata_path=/tmp/fair-metadata.json', $outputContent);
 
         $metadata = json_decode((string) file_get_contents('/tmp/fair-metadata.json'), true, 512, JSON_THROW_ON_ERROR);
+        $expectedSlug = basename($workspaceDir);
         self::assertSame('did:plc:metadata123', $metadata['id']);
         self::assertSame('https://fair.pm/ns/metadata/v1', $metadata['@context']);
         self::assertSame('wp-plugin', $metadata['type']);
-        self::assertSame('example-plugin/example-plugin.php', $metadata['filename']);
+        self::assertSame($expectedSlug, $metadata['slug']);
+        self::assertSame($expectedSlug . '/example-plugin.php', $metadata['filename']);
         self::assertSame('1.2.3', $metadata['releases'][0]['version']);
         self::assertSame('signature123', $metadata['releases'][0]['artifacts']['package'][0]['signature']);
         self::assertSame('sha256:' . str_repeat('a', 64), $metadata['releases'][0]['artifacts']['package'][0]['checksum']);

--- a/tests/Unit/MetadataGenerationServiceTest.php
+++ b/tests/Unit/MetadataGenerationServiceTest.php
@@ -9,6 +9,44 @@ use PHPUnit\Framework\TestCase;
 
 final class MetadataGenerationServiceTest extends TestCase
 {
+    public function testGenerateUsesPluginDirectoryNameForSlug(): void
+    {
+        $baseTempDir = sys_get_temp_dir() . '/fair-workspace-' . bin2hex(random_bytes(5));
+        $workspaceDir = $baseTempDir . '/plugin-directory-slug';
+        mkdir($workspaceDir, 0777, true);
+
+        file_put_contents(
+            $workspaceDir . '/entrypoint.php',
+            "<?php\n/*\nPlugin Name: Example Plugin\nRequires PHP: 8.1\nRequires at least: 6.5\n*/\n"
+        );
+
+        file_put_contents(
+            $workspaceDir . '/readme.txt',
+            "=== Example Plugin ===\n"
+            . "Requires at least: 6.5\n"
+            . "Requires PHP: 8.1\n"
+            . "Stable tag: 1.2.3\n\n"
+            . "Example plugin short description.\n"
+        );
+
+        $artifactPath = tempnam(sys_get_temp_dir(), 'fair-artifact-');
+        file_put_contents($artifactPath, 'artifact-content');
+
+        $service = new MetadataGenerationService();
+        $metadata = $service->generate(
+            'did:plc:metadata123',
+            'v1.2.3',
+            'sha256:' . str_repeat('a', 64),
+            'signature123',
+            $artifactPath,
+            'https://github.com/fairpm/fair-pulse',
+            $workspaceDir,
+        );
+
+        self::assertSame('plugin-directory-slug', $metadata['slug'] ?? null);
+        self::assertSame('plugin-directory-slug/entrypoint.php', $metadata['filename'] ?? null);
+    }
+
     public function testGenerateDeduplicatesContributorThatMatchesPrimaryAuthor(): void
     {
         $workspaceDir = sys_get_temp_dir() . '/fair-workspace-' . bin2hex(random_bytes(5));


### PR DESCRIPTION
Derive a package slug from the workspace directory name and prefer it when building metadata. MetadataGenerationService now computes packageSlug from workDir and passes it into normalizeMetadata; normalizeMetadata will use the trimmed packageSlug if present and fall back to raw metadata/header values only when it's empty. Added a unit test (testGenerateUsesPluginDirectoryNameForSlug) that verifies the slug and filename are based on the plugin directory name.